### PR TITLE
Create p4est and query points only when expected

### DIFF
--- a/src/driver.cxx
+++ b/src/driver.cxx
@@ -39,7 +39,7 @@ void driver_t::initialize(int argc,char **argv){
     flow->initialize();
 
     /* get pointers from flow solver */
-    flow->flow_set_pointers();
+    flow->flow_set_pointers(group_index);
 
     /* initialize p4est_overset: p4est bg mesh must be group_index=0 */
     p4est_overset->p4est_overset_init(mpicomm,leader_comm,group_comm,

--- a/src/driver.cxx
+++ b/src/driver.cxx
@@ -43,7 +43,7 @@ void driver_t::initialize(int argc,char **argv){
 
     /* initialize p4est_overset: p4est bg mesh must be group_index=0 */
     p4est_overset->p4est_overset_init(mpicomm,leader_comm,group_comm,
-                                      group_index,group_index,
+                                      group_index,ngroups,
                                       mesh_rank_offsets,
                                       flow->p4est,
                                       flow->qpoints);

--- a/src/flow_solver.h
+++ b/src/flow_solver.h
@@ -284,7 +284,7 @@ public:
   void flow_load_dynamic_library();
   void flow_close_dynamic_library();
   void flow_initialize_group_mpi(MPI_Comm group_comm);
-  void flow_set_pointers();
+  void flow_set_pointers(int group_index);
   void flow_output_solution(int t);
   void flow_point_inclusion(int *npoint, double *x, int *cell_id);
 };


### PR DESCRIPTION
In the newest version of the p4est feature-multi-branch we added a few assertions that failed when running the structured.2D example. In p4est_multi_overset we assume that the p4est is only defined iff we are at the background mesh (myrole ==0) and the qpoints are only defined iff we are at a near-body mesh (myrole > 0).
I propose a simple fix for this.

CC: @cburstedde